### PR TITLE
Rebuild zod path of OpenAPI pipeline (v4 support) and add structured errors

### DIFF
--- a/.changeset/openapi-builder.md
+++ b/.changeset/openapi-builder.md
@@ -1,0 +1,8 @@
+---
+"@ts-api-kit/core": minor
+---
+
+Rebuild the zod path of the OpenAPI pipeline for zod v4 and surface structured errors.
+
+- **Zod v4 support.** `zToJsonSchema` and `zodObjectToParams` were written against zod v3 internals (`_def.typeName === "ZodString"`, etc.). The package's peer dep declares zod ^4 and v4 restructured the schema (`.def.type` in lowercase, `def.element`, `def.values`, `def.entries`, `def.in` / `def.out`). Before this change every zod schema fell through to the default branch and users got empty OpenAPI bodies and parameters without types; now the full spectrum — primitives, arrays, literals, enums, unions, optional / default / nullable wrappers, objects with mixed required/optional props, and transforms — produces the expected JSON Schema. All internal reads against zod go through a dedicated `schema-introspection` module, replacing every `as any` cast that biome previously flagged.
+- **Structured OpenAPI errors.** Introduces `OpenAPIError`, a typed error class exported from `@ts-api-kit/core/openapi`. It carries a `stage` (`route-method-conflict` / `route-path-conflict` / `generator-file` / `generator-write`) plus optional `route`, `method`, and `filePath` context. `mountFileRouter`'s method / path consistency checks and the compiler's per-file processing now throw it, so diagnostic output points at the failing route instead of a generic "Error generating OpenAPI specification".

--- a/packages/core/src/file-router.ts
+++ b/packages/core/src/file-router.ts
@@ -5,6 +5,7 @@ import type { Handler, Hono, MiddlewareHandler } from "hono";
 import { dirname, join, relative as relPath, resolve } from "pathe";
 import { configToMiddleware, type DirConfig } from "./config.ts";
 import { registerScopedError, registerScopedNotFound } from "./hooks.ts";
+import { OpenAPIError } from "./openapi/errors.ts";
 import type { HttpMethod } from "./openapi/registry.ts";
 import { lazyRegister } from "./openapi/registry.ts";
 import {
@@ -541,15 +542,27 @@ export async function mountFileRouter(
 
 			// Validation: ensure consistency between export name and declared method
 			if (mergedOA.method && mergedOA.method !== method) {
-				throw new Error(
+				throw new OpenAPIError(
 					`OpenAPI method conflict: export "${exportName}" suggests "${method}" but OpenAPI declares "${mergedOA.method}".`,
+					{
+						stage: "route-method-conflict",
+						route: openapi,
+						method,
+						filePath: file,
+					},
 				);
 			}
 
 			// Validation: ensure consistency between derived and declared path
 			if (mergedOA.path && mergedOA.path !== openapi) {
-				throw new Error(
+				throw new OpenAPIError(
 					`OpenAPI path conflict: file "${file}" derives "${openapi}" but OpenAPI declares "${mergedOA.path}".`,
+					{
+						stage: "route-path-conflict",
+						route: openapi,
+						method,
+						filePath: file,
+					},
 				);
 			}
 

--- a/packages/core/src/openapi/builder.test.ts
+++ b/packages/core/src/openapi/builder.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import * as z from "zod";
+import { zToJsonSchema } from "./builder.ts";
+
+describe("zToJsonSchema", () => {
+	it("converts primitive schemas", () => {
+		assert.deepEqual(zToJsonSchema(z.string()), { type: "string" });
+		assert.deepEqual(zToJsonSchema(z.number()), { type: "number" });
+		assert.deepEqual(zToJsonSchema(z.boolean()), { type: "boolean" });
+	});
+
+	it("passes through unknown as empty schema", () => {
+		assert.deepEqual(zToJsonSchema(z.unknown()), {});
+		assert.deepEqual(zToJsonSchema(z.any()), {});
+	});
+
+	it("converts arrays", () => {
+		assert.deepEqual(zToJsonSchema(z.array(z.string())), {
+			type: "array",
+			items: { type: "string" },
+		});
+	});
+
+	it("converts literal schemas to typed enums", () => {
+		assert.deepEqual(zToJsonSchema(z.literal("admin")), {
+			enum: ["admin"],
+			type: "string",
+		});
+		assert.deepEqual(zToJsonSchema(z.literal(42)), {
+			enum: [42],
+			type: "number",
+		});
+		assert.deepEqual(zToJsonSchema(z.literal(true)), {
+			enum: [true],
+			type: "boolean",
+		});
+	});
+
+	it("converts enum schemas", () => {
+		assert.deepEqual(zToJsonSchema(z.enum(["read", "write"])), {
+			enum: ["read", "write"],
+			type: "string",
+		});
+	});
+
+	it("collapses a union of string literals to a typed enum", () => {
+		const schema = z.union([z.literal("a"), z.literal("b"), z.literal("c")]);
+		assert.deepEqual(zToJsonSchema(schema), {
+			enum: ["a", "b", "c"],
+			type: "string",
+		});
+	});
+
+	it("falls back to anyOf for mixed unions", () => {
+		const schema = z.union([z.string(), z.number()]);
+		assert.deepEqual(zToJsonSchema(schema), {
+			anyOf: [{ type: "string" }, { type: "number" }],
+		});
+	});
+
+	it("unwraps optional schemas to the inner type", () => {
+		assert.deepEqual(zToJsonSchema(z.string().optional()), { type: "string" });
+	});
+
+	it("unwraps default schemas to the inner type", () => {
+		assert.deepEqual(zToJsonSchema(z.string().default("hi")), {
+			type: "string",
+		});
+	});
+
+	it("renders nullable schemas as anyOf with null", () => {
+		assert.deepEqual(zToJsonSchema(z.string().nullable()), {
+			anyOf: [{ type: "string" }, { type: "null" }],
+		});
+	});
+
+	it("converts object schemas with a mix of required/optional props", () => {
+		const schema = z.object({
+			id: z.number(),
+			name: z.string(),
+			nickname: z.string().optional(),
+		});
+		const result = zToJsonSchema(schema) as {
+			type: string;
+			properties: Record<string, unknown>;
+			required: string[];
+		};
+		assert.equal(result.type, "object");
+		assert.deepEqual(result.properties, {
+			id: { type: "number" },
+			name: { type: "string" },
+			nickname: { type: "string" },
+		});
+		assert.deepEqual(result.required, ["id", "name"]);
+	});
+
+	it("documents the input schema of a transform pipe", () => {
+		const schema = z.string().transform((v) => Number(v));
+		assert.deepEqual(zToJsonSchema(schema), { type: "string" });
+	});
+
+	it("nested object with arrays and enums round-trips", () => {
+		const schema = z.object({
+			tags: z.array(z.enum(["api", "docs"])),
+			role: z.union([z.literal("admin"), z.literal("user")]),
+		});
+		const result = zToJsonSchema(schema) as {
+			type: string;
+			properties: Record<string, unknown>;
+			required: string[];
+		};
+		assert.equal(result.type, "object");
+		assert.deepEqual(result.properties, {
+			tags: {
+				type: "array",
+				items: { enum: ["api", "docs"], type: "string" },
+			},
+			role: { enum: ["admin", "user"], type: "string" },
+		});
+		assert.deepEqual(result.required.sort(), ["role", "tags"]);
+	});
+});

--- a/packages/core/src/openapi/builder.ts
+++ b/packages/core/src/openapi/builder.ts
@@ -5,6 +5,18 @@ import type * as z from "zod";
 import { readParameterJSDoc } from "../utils/jsdoc-extractor.ts";
 import { createLogger } from "../utils/logger.ts";
 import type { ResponseMarker } from "./markers.ts";
+import {
+	isZodLiteral,
+	isZodOptional,
+	zodArrayElement,
+	zodEnumValues,
+	zodInnerType,
+	zodLiteralValues,
+	zodPipeInput,
+	zodShape,
+	zodTypeName,
+	zodUnionOptions,
+} from "./schema-introspection.ts";
 
 // Local, safer alias for generic response typing
 type AnySchema = unknown;
@@ -201,105 +213,86 @@ export const vToJsonSchema = (
 	}
 };
 
-// Basic Zod -> JSON Schema converter for common types used by the kit
+// Basic Zod -> JSON Schema converter for common types used by the kit.
+// Targets zod v4, which exposes its metadata via `.def` with lowercase
+// `type` names. All introspection goes through the helpers in
+// `schema-introspection.ts` — this function never reads `_def` directly.
+
 type ZodAny = z.ZodTypeAny;
-type ZodObjectDef = {
-	typeName: string;
-	shape?: () => Record<string, ZodAny>;
-};
 
 function isZodSchema(s: unknown): s is ZodAny {
 	return (
 		!!s &&
 		typeof s === "object" &&
 		typeof (s as { safeParse?: unknown }).safeParse === "function" &&
-		"_def" in (s as object)
+		// zod v4 exposes `def` directly; legacy `_def` kept for detection of
+		// any v3-shaped imposters (we still treat them as zod for dispatch).
+		("def" in (s as object) || "_def" in (s as object))
 	);
 }
 
-export const zToJsonSchema = (schema: ZodAny): Json => {
-	const s = schema as ZodAny & {
-		_def: {
-			typeName: string;
-			innerType?: ZodAny;
-			type?: ZodAny;
-			options?: ZodAny[];
-			values?: unknown[];
-			schema?: ZodAny;
-			shape?: () => Record<string, ZodAny>;
-		};
-	};
-	const t = s._def?.typeName;
+const primitiveEnum = (values: readonly unknown[]): Record<string, unknown> => {
+	const out: Record<string, unknown> = { enum: [...values] };
+	const ty = typeof values[0];
+	if (ty === "string" || ty === "number" || ty === "boolean") out.type = ty;
+	return out;
+};
 
-	switch (t) {
-		case "ZodString":
+export const zToJsonSchema = (schema: ZodAny): Json => {
+	switch (zodTypeName(schema)) {
+		case "string":
 			return { type: "string" };
-		case "ZodNumber":
+		case "number":
 			return { type: "number" };
-		case "ZodBoolean":
+		case "boolean":
 			return { type: "boolean" };
-		case "ZodUnknown":
-		case "ZodAny":
+		case "unknown":
+		case "any":
 			return {};
-		case "ZodArray": {
-			const item = (s._def as { type?: ZodAny }).type;
-			return { type: "array", items: item ? zToJsonSchema(item) : {} };
+		case "array": {
+			const item = zodArrayElement(schema);
+			return {
+				type: "array",
+				items: item ? zToJsonSchema(item as ZodAny) : {},
+			};
 		}
-		case "ZodLiteral": {
-			const val = (
-				s._def as { value?: unknown } as unknown as { value?: unknown }
-			).value;
-			const out: Record<string, unknown> = { enum: [val] };
-			const ty = typeof val;
-			if (ty === "string" || ty === "number" || ty === "boolean") out.type = ty;
-			return out as unknown as Json;
+		case "literal": {
+			const values = zodLiteralValues(schema) ?? [];
+			return primitiveEnum(values) as unknown as Json;
 		}
-		case "ZodEnum": {
-			const values = (s._def as { values?: unknown[] }).values ?? [];
-			const out: Record<string, unknown> = { enum: values };
-			const ty = typeof values[0];
-			if (ty === "string" || ty === "number" || ty === "boolean") out.type = ty;
-			return out as unknown as Json;
+		case "enum": {
+			const values = zodEnumValues(schema) ?? [];
+			return primitiveEnum(values) as unknown as Json;
 		}
-		case "ZodUnion": {
-			const opts = (s._def as { options?: ZodAny[] }).options ?? [];
-			// collapse union of literals to enum when possible
-			const allLiteral =
-				opts.length &&
-				opts.every((o) => (o as any)?._def?.typeName === "ZodLiteral");
-			if (allLiteral) {
-				const values = opts.map((o) => (o as any)?._def?.value);
-				const out: Record<string, unknown> = { enum: values };
-				const ty = typeof values[0];
-				if (ty === "string" || ty === "number" || ty === "boolean")
-					out.type = ty;
-				return out as unknown as Json;
+		case "union": {
+			const opts = (zodUnionOptions(schema) ?? []) as ZodAny[];
+			// collapse union of literals to a typed enum when every branch is
+			// a single literal (the common shape for discriminator-style unions).
+			if (opts.length && opts.every(isZodLiteral)) {
+				const values = opts.flatMap((o) => zodLiteralValues(o) ?? []);
+				return primitiveEnum(values) as unknown as Json;
 			}
-			return { anyOf: opts.map((o) => zToJsonSchema(o)) } as unknown as Json;
+			return {
+				anyOf: opts.map((o) => zToJsonSchema(o)),
+			} as unknown as Json;
 		}
-		case "ZodOptional": {
-			const inner = (s._def as { innerType?: ZodAny }).innerType;
-			return inner ? zToJsonSchema(inner) : {};
+		case "optional":
+		case "default": {
+			const inner = zodInnerType(schema);
+			return inner ? zToJsonSchema(inner as ZodAny) : {};
 		}
-		case "ZodDefault": {
-			const inner = (s._def as { innerType?: ZodAny }).innerType;
-			return inner ? zToJsonSchema(inner) : {};
-		}
-		case "ZodNullable": {
-			const inner = (s._def as { innerType?: ZodAny }).innerType;
-			const base = inner ? zToJsonSchema(inner) : {};
-			// basic nullable handling (OpenAPI 3.1)
+		case "nullable": {
+			const inner = zodInnerType(schema);
+			const base = inner ? zToJsonSchema(inner as ZodAny) : {};
 			return { anyOf: [base, { type: "null" }] } as unknown as Json;
 		}
-		case "ZodObject": {
-			const def = s._def as unknown as ZodObjectDef;
-			const shape = (schema as any).shape ?? def.shape?.();
+		case "object": {
+			const shape = zodShape(schema) ?? {};
 			const props: Record<string, Json> = {};
 			const required: string[] = [];
-			for (const [k, child] of Object.entries(shape ?? {})) {
+			for (const [k, child] of Object.entries(shape)) {
 				props[k] = zToJsonSchema(child as ZodAny);
-				const ct = (child as any)?._def?.typeName;
-				if (ct !== "ZodOptional") required.push(k);
+				if (!isZodOptional(child)) required.push(k);
 			}
 			const out: Record<string, unknown> = {
 				type: "object",
@@ -308,9 +301,12 @@ export const zToJsonSchema = (schema: ZodAny): Json => {
 			if (required.length) (out as { required?: string[] }).required = required;
 			return out as unknown as Json;
 		}
-		case "ZodEffects": {
-			const inner = (s._def as { schema?: ZodAny }).schema;
-			return inner ? zToJsonSchema(inner) : {};
+		case "pipe": {
+			// zod v4 transforms live in a `pipe` whose `in` is the source schema
+			// and `out` is the transform itself. We document the input type
+			// because that is what an OpenAPI client actually sends.
+			const input = zodPipeInput(schema);
+			return input ? zToJsonSchema(input as ZodAny) : {};
 		}
 		default:
 			return {};
@@ -751,13 +747,10 @@ function zodObjectToParams(
 	where: "query" | "path" | "header",
 	filePath?: string,
 ): ParameterObject[] {
-	const entries: Record<string, z.ZodTypeAny> =
-		(schema as any)?.shape ?? (schema as any)?._def?.shape?.() ?? {};
+	const entries = (zodShape(schema) ?? {}) as Record<string, z.ZodTypeAny>;
 	const out: ParameterObject[] = [];
 	for (const [name, sch] of Object.entries(entries)) {
-		const typeName = (sch as any)?._def?.typeName as string | undefined;
-		const isOptional = typeName === "ZodOptional";
-		const required = !isOptional && where !== "header";
+		const required = !isZodOptional(sch) && where !== "header";
 		const jsonSchema = zToJsonSchema(sch as z.ZodTypeAny);
 		const param: ParameterObject = {
 			name,

--- a/packages/core/src/openapi/errors.test.ts
+++ b/packages/core/src/openapi/errors.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { OpenAPIError } from "./errors.ts";
+
+describe("OpenAPIError", () => {
+	it("stores the stage and optional context on the instance", () => {
+		const err = new OpenAPIError("method conflict", {
+			stage: "route-method-conflict",
+			route: "/users/:id",
+			method: "get",
+			filePath: "/app/src/routes/users/[id]/+route.ts",
+		});
+
+		assert.equal(err.name, "OpenAPIError");
+		assert.equal(err.stage, "route-method-conflict");
+		assert.equal(err.route, "/users/:id");
+		assert.equal(err.method, "get");
+		assert.equal(err.filePath, "/app/src/routes/users/[id]/+route.ts");
+		assert.equal(err.message, "method conflict");
+	});
+
+	it("is an instance of Error so existing catch blocks keep working", () => {
+		const err = new OpenAPIError("x", { stage: "generator-write" });
+		assert.ok(err instanceof Error);
+		assert.ok(err instanceof OpenAPIError);
+	});
+
+	it("accepts a cause and exposes it both on the native slot and as a property", () => {
+		const underlying = new Error("ENOENT");
+		const err = new OpenAPIError("write failed", {
+			stage: "generator-write",
+			cause: underlying,
+		});
+
+		assert.equal(err.cause, underlying);
+	});
+
+	describe("wrap", () => {
+		it("prefixes the underlying message with stage + route + method", () => {
+			const err = OpenAPIError.wrap(new Error("expected schema"), {
+				stage: "generator-file",
+				route: "/users/{id}",
+				method: "get",
+				filePath: "/app/src/routes/users/[id]/+route.ts",
+			});
+
+			assert.ok(err.message.startsWith("OpenAPI [generator-file]"));
+			assert.ok(err.message.includes("GET /users/{id}"));
+			assert.ok(err.message.includes("/app/src/routes/users/[id]/+route.ts"));
+			assert.ok(err.message.endsWith("expected schema"));
+			assert.equal(err.stage, "generator-file");
+		});
+
+		it("handles non-Error thrown values", () => {
+			const err = OpenAPIError.wrap("boom", {
+				stage: "generator-file",
+				route: "/x",
+			});
+			assert.equal(err.cause, "boom");
+			assert.ok(err.message.includes("boom"));
+		});
+
+		it("falls back to a generic message when the thrown value is empty", () => {
+			const err = OpenAPIError.wrap(undefined, {
+				stage: "generator-write",
+			});
+			assert.ok(err.message.includes("OpenAPI pipeline failed"));
+			assert.equal(err.cause, undefined);
+		});
+
+		it("returns the original error when it's already an OpenAPIError (no nesting)", () => {
+			const original = new OpenAPIError("initial", {
+				stage: "route-path-conflict",
+				route: "/a",
+			});
+			const wrapped = OpenAPIError.wrap(original, {
+				stage: "generator-file",
+				route: "/b",
+			});
+			assert.equal(wrapped, original);
+		});
+	});
+});

--- a/packages/core/src/openapi/errors.ts
+++ b/packages/core/src/openapi/errors.ts
@@ -1,0 +1,98 @@
+// Structured error type for all OpenAPI-related failures emitted by
+// `@ts-api-kit/core`. The kit has three distinct OpenAPI surfaces
+// (runtime route registration, OpenAPI document assembly, and the
+// compiler that walks source files), and the previous "Failed to
+// generate OpenAPI specification" message left consumers guessing
+// which surface / which route / which stage actually failed.
+//
+// Callers can match on `error instanceof OpenAPIError` and branch on
+// `error.stage` to surface useful diagnostics.
+
+/**
+ * Identifies where in the OpenAPI pipeline a failure happened. Keep this
+ * list stable — it's part of the public error contract and downstream
+ * tooling may switch on it.
+ */
+export type OpenAPIErrorStage =
+	/** `mountFileRouter` found a route whose derived HTTP method disagrees with the handler's declared `openapi.method`. */
+	| "route-method-conflict"
+	/** `mountFileRouter` found a route whose derived path disagrees with the handler's declared `openapi.path`. */
+	| "route-path-conflict"
+	/** The generator / compiler failed while processing one source file. */
+	| "generator-file"
+	/** The generator failed while writing the final OpenAPI document. */
+	| "generator-write";
+
+/**
+ * Context a caller can attach to an {@link OpenAPIError} when throwing.
+ * Every field is optional because not every stage has access to every
+ * piece of context — e.g. a write failure has no route.
+ */
+export type OpenAPIErrorContext = {
+	stage: OpenAPIErrorStage;
+	/** Hono / OpenAPI path that was being processed, when known. */
+	route?: string;
+	/** HTTP method that was being processed, when known. */
+	method?: string;
+	/** Absolute source file the error originated in, when known. */
+	filePath?: string;
+	/** Underlying error, if this one wraps something else. */
+	cause?: unknown;
+};
+
+/**
+ * Error thrown by the OpenAPI pipeline. Carries structured context so
+ * consumers can programmatically react (or just log something useful).
+ */
+export class OpenAPIError extends Error {
+	readonly stage: OpenAPIErrorStage;
+	readonly route?: string;
+	readonly method?: string;
+	readonly filePath?: string;
+	override readonly cause?: unknown;
+
+	constructor(message: string, context: OpenAPIErrorContext) {
+		// Node's Error supports { cause } but we also expose it as an own
+		// property for easy access from environments that don't serialize
+		// `cause` on their own.
+		super(message, context.cause ? { cause: context.cause } : undefined);
+		this.name = "OpenAPIError";
+		this.stage = context.stage;
+		this.route = context.route;
+		this.method = context.method;
+		this.filePath = context.filePath;
+		this.cause = context.cause;
+	}
+
+	/**
+	 * Wraps an unknown thrown value, adding OpenAPI pipeline context.
+	 * If the value is already an {@link OpenAPIError}, the original is
+	 * returned unchanged so context doesn't get stacked twice.
+	 */
+	static wrap(
+		error: unknown,
+		context: OpenAPIErrorContext,
+		fallbackMessage = "OpenAPI pipeline failed",
+	): OpenAPIError {
+		if (error instanceof OpenAPIError) return error;
+		const underlying =
+			error instanceof Error ? error.message : String(error ?? "");
+		const prefix = describeLocation(context);
+		const message = underlying
+			? `${prefix}: ${underlying}`
+			: `${prefix}: ${fallbackMessage}`;
+		return new OpenAPIError(message, { ...context, cause: error });
+	}
+}
+
+function describeLocation(context: OpenAPIErrorContext): string {
+	const parts: string[] = [];
+	parts.push(`OpenAPI [${context.stage}]`);
+	if (context.method && context.route) {
+		parts.push(`${context.method.toUpperCase()} ${context.route}`);
+	} else if (context.route) {
+		parts.push(context.route);
+	}
+	if (context.filePath) parts.push(`(${context.filePath})`);
+	return parts.join(" ");
+}

--- a/packages/core/src/openapi/generator/index.ts
+++ b/packages/core/src/openapi/generator/index.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import process from "node:process";
 import ts from "typescript";
 import { createLogger } from "../../utils/logger.ts";
+import { OpenAPIError } from "../errors.ts";
 
 type Json = Record<string, unknown> | Json[] | string | number | boolean | null;
 
@@ -1296,8 +1297,19 @@ export async function generateOpenAPI(
 
 			log.debug(`Derived OpenAPI path: ${openapiPath}`);
 
-			// Process the source file to find exported HTTP methods
-			const operations = processRouteFile(sourceFile, checker);
+			// Process the source file to find exported HTTP methods. Per-file
+			// failures are rewrapped with route context so operators can see
+			// which route blew up instead of just "Error generating OpenAPI".
+			let operations: OperationMap;
+			try {
+				operations = processRouteFile(sourceFile, checker);
+			} catch (cause) {
+				throw OpenAPIError.wrap(cause, {
+					stage: "generator-file",
+					route: openapiPath,
+					filePath: relativePath,
+				});
+			}
 
 			if (Object.keys(operations).length > 0) {
 				openapiSpec.paths[openapiPath] ??= operations;
@@ -1311,10 +1323,22 @@ export async function generateOpenAPI(
 		openapiSpec.components.schemas = schemaRegistry.getSchemas();
 
 		// Write the generated OpenAPI spec to file
-		await fs.writeFile(outputPath, JSON.stringify(openapiSpec, null, 2));
+		try {
+			await fs.writeFile(outputPath, JSON.stringify(openapiSpec, null, 2));
+		} catch (cause) {
+			throw OpenAPIError.wrap(cause, {
+				stage: "generator-write",
+				filePath: outputPath,
+			});
+		}
 		log.info(`✅ OpenAPI specification generated: ${outputPath}`);
 	} catch (error) {
-		log.error("❌ Error generating OpenAPI specification:", error);
+		if (error instanceof OpenAPIError) {
+			log.error(`❌ ${error.message}`);
+			if (error.cause && error.cause !== error) log.error(error.cause);
+		} else {
+			log.error("❌ Error generating OpenAPI specification:", error);
+		}
 		process.exit(1);
 	}
 }

--- a/packages/core/src/openapi/index.ts
+++ b/packages/core/src/openapi/index.ts
@@ -11,6 +11,7 @@
  */
 
 export * from "./builder.ts";
+export * from "./errors.ts";
 export * from "./markers.ts";
 export * from "./presets.ts";
 export * from "./registry.ts";

--- a/packages/core/src/openapi/schema-introspection.test.ts
+++ b/packages/core/src/openapi/schema-introspection.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import * as z from "zod";
+import {
+	isZodLiteral,
+	isZodOptional,
+	zodArrayElement,
+	zodDef,
+	zodEnumValues,
+	zodInnerType,
+	zodLiteralValues,
+	zodPipeInput,
+	zodShape,
+	zodTypeName,
+	zodUnionOptions,
+} from "./schema-introspection.ts";
+
+describe("schema-introspection (zod v4)", () => {
+	describe("zodDef", () => {
+		it("returns the def block of a zod schema", () => {
+			const def = zodDef(z.string());
+			assert.ok(def);
+			assert.equal(def.type, "string");
+		});
+
+		it("returns {} for non-zod values", () => {
+			assert.deepEqual(zodDef(undefined), {});
+			assert.deepEqual(zodDef(null), {});
+			assert.deepEqual(zodDef("string"), {});
+			assert.deepEqual(zodDef({ foo: "bar" }), {});
+		});
+	});
+
+	describe("zodTypeName", () => {
+		it("reports lowercase type names for primitives", () => {
+			assert.equal(zodTypeName(z.string()), "string");
+			assert.equal(zodTypeName(z.number()), "number");
+			assert.equal(zodTypeName(z.boolean()), "boolean");
+		});
+
+		it("reports 'literal' for literal schemas", () => {
+			assert.equal(zodTypeName(z.literal("admin")), "literal");
+			assert.equal(zodTypeName(z.literal(42)), "literal");
+		});
+
+		it("reports 'optional' for optional wrappers", () => {
+			assert.equal(zodTypeName(z.string().optional()), "optional");
+		});
+
+		it("reports 'object' for object schemas", () => {
+			assert.equal(zodTypeName(z.object({ a: z.string() })), "object");
+		});
+
+		it("reports 'union' for union schemas", () => {
+			assert.equal(zodTypeName(z.union([z.string(), z.number()])), "union");
+		});
+
+		it("reports 'enum' for enum schemas", () => {
+			assert.equal(zodTypeName(z.enum(["x", "y"])), "enum");
+		});
+
+		it("reports 'array' for array schemas", () => {
+			assert.equal(zodTypeName(z.array(z.string())), "array");
+		});
+
+		it("returns undefined for non-zod input", () => {
+			assert.equal(zodTypeName({}), undefined);
+			assert.equal(zodTypeName(null), undefined);
+			assert.equal(zodTypeName("literal"), undefined);
+		});
+	});
+
+	describe("zodLiteralValues", () => {
+		it("returns the literal values array", () => {
+			assert.deepEqual(zodLiteralValues(z.literal("admin")), ["admin"]);
+			assert.deepEqual(zodLiteralValues(z.literal(7)), [7]);
+			assert.deepEqual(zodLiteralValues(z.literal(true)), [true]);
+		});
+
+		it("returns undefined for non-literal schemas", () => {
+			assert.equal(zodLiteralValues(z.string()), undefined);
+		});
+	});
+
+	describe("zodEnumValues", () => {
+		it("returns the enum values", () => {
+			assert.deepEqual(zodEnumValues(z.enum(["x", "y"])), ["x", "y"]);
+		});
+
+		it("returns undefined for non-enum schemas", () => {
+			assert.equal(zodEnumValues(z.string()), undefined);
+		});
+	});
+
+	describe("zodShape", () => {
+		it("returns the shape map of a ZodObject", () => {
+			const shape = zodShape(z.object({ a: z.string(), b: z.number() }));
+			assert.ok(shape);
+			assert.deepEqual(Object.keys(shape), ["a", "b"]);
+			assert.equal(zodTypeName(shape.a), "string");
+			assert.equal(zodTypeName(shape.b), "number");
+		});
+
+		it("returns undefined for non-object schemas", () => {
+			assert.equal(zodShape(z.string()), undefined);
+			assert.equal(zodShape(z.literal("x")), undefined);
+		});
+
+		it("returns undefined for non-zod input", () => {
+			assert.equal(zodShape(undefined), undefined);
+			assert.equal(zodShape({}), undefined);
+		});
+	});
+
+	describe("zodInnerType", () => {
+		it("returns the wrapped schema for optional", () => {
+			const inner = zodInnerType(z.string().optional());
+			assert.equal(zodTypeName(inner), "string");
+		});
+
+		it("returns the wrapped schema for default", () => {
+			const inner = zodInnerType(z.string().default("hi"));
+			assert.equal(zodTypeName(inner), "string");
+		});
+
+		it("returns the wrapped schema for nullable", () => {
+			const inner = zodInnerType(z.string().nullable());
+			assert.equal(zodTypeName(inner), "string");
+		});
+
+		it("returns undefined for non-wrapper schemas", () => {
+			assert.equal(zodInnerType(z.string()), undefined);
+			assert.equal(zodInnerType(z.object({ a: z.string() })), undefined);
+		});
+	});
+
+	describe("zodUnionOptions", () => {
+		it("returns the branches of a union", () => {
+			const options = zodUnionOptions(z.union([z.string(), z.number()]));
+			assert.ok(options);
+			assert.equal(options.length, 2);
+			assert.equal(zodTypeName(options[0]), "string");
+			assert.equal(zodTypeName(options[1]), "number");
+		});
+	});
+
+	describe("zodArrayElement", () => {
+		it("returns the item schema of an array", () => {
+			const element = zodArrayElement(z.array(z.number()));
+			assert.equal(zodTypeName(element), "number");
+		});
+	});
+
+	describe("zodPipeInput", () => {
+		it("returns the input schema of a pipe/transform", () => {
+			const input = zodPipeInput(z.string().transform((v) => Number(v)));
+			assert.equal(zodTypeName(input), "string");
+		});
+
+		it("returns undefined for non-pipe schemas", () => {
+			assert.equal(zodPipeInput(z.string()), undefined);
+		});
+	});
+
+	describe("isZodOptional", () => {
+		it("recognises optional schemas", () => {
+			assert.equal(isZodOptional(z.string().optional()), true);
+			assert.equal(isZodOptional(z.number().optional()), true);
+		});
+
+		it("returns false for non-optional schemas", () => {
+			assert.equal(isZodOptional(z.string()), false);
+			assert.equal(isZodOptional({}), false);
+		});
+	});
+
+	describe("isZodLiteral", () => {
+		it("recognises literal schemas", () => {
+			assert.equal(isZodLiteral(z.literal("x")), true);
+		});
+
+		it("returns false for non-literal schemas", () => {
+			assert.equal(isZodLiteral(z.string()), false);
+			assert.equal(isZodLiteral(z.object({ a: z.string() })), false);
+		});
+	});
+});

--- a/packages/core/src/openapi/schema-introspection.ts
+++ b/packages/core/src/openapi/schema-introspection.ts
@@ -1,0 +1,114 @@
+// Typed helpers for reaching into the internals of Zod schemas without
+// scattering `as any` casts. We deliberately keep these narrow: the OpenAPI
+// builder only needs `type`, literal `values`, object `shape`, and a handful
+// of wrapper accessors. If zod changes its internal shape, updates live here
+// in one place.
+//
+// Targets zod v4 (the version declared in the package's peer deps). In v4
+// schemas expose their metadata on `.def` (not `._def`) and use lowercase
+// `type` names ("string", "object", "literal", ...) — not the v3-era
+// "ZodString"/"ZodObject"/... identifiers the builder used to compare
+// against.
+//
+// These helpers never throw; they return `undefined` / empty structures
+// when the schema does not match the expected shape. The caller decides how
+// to handle it.
+
+/**
+ * Minimal description of the `def` payload zod v4 attaches to every schema.
+ * Only the fields we read today are listed — extend as needed.
+ */
+export type ZodDef = {
+	type?: string;
+	// literal: def.values is an array of the allowed literal values
+	values?: unknown[];
+	// enum: def.entries is a { key: value } map
+	entries?: Record<string, unknown>;
+	// array: def.element is the item schema
+	element?: unknown;
+	// optional / default / nullable: def.innerType is the wrapped schema
+	innerType?: unknown;
+	// union / discriminated union: def.options is an array of branch schemas
+	options?: unknown[];
+	// object: def.shape is a direct map; the instance also exposes `.shape`
+	shape?: Record<string, unknown>;
+	// pipe (transform): def.in is the input schema, def.out is the transform
+	in?: unknown;
+	out?: unknown;
+	// default: def.defaultValue holds the fallback value
+	defaultValue?: unknown;
+};
+
+type MaybeZodSchema = {
+	def?: ZodDef;
+	// `.shape` is exposed directly on `ZodObject` instances for convenience.
+	shape?: Record<string, unknown>;
+};
+
+function asMaybeZod(schema: unknown): MaybeZodSchema {
+	return schema && typeof schema === "object" ? (schema as MaybeZodSchema) : {};
+}
+
+/** Reads the `def` block off a zod v4 schema, or returns `{}`. */
+export function zodDef(schema: unknown): ZodDef {
+	return asMaybeZod(schema).def ?? {};
+}
+
+/** Returns the schema's `type` (e.g. `"string"`, `"literal"`, `"object"`) or `undefined`. */
+export function zodTypeName(schema: unknown): string | undefined {
+	return zodDef(schema).type;
+}
+
+/** Returns the `def.values` stored on a zod v4 `literal` schema. */
+export function zodLiteralValues(schema: unknown): unknown[] | undefined {
+	return zodDef(schema).values;
+}
+
+/** Returns the values of a zod v4 `enum` schema (extracted from `def.entries`). */
+export function zodEnumValues(schema: unknown): unknown[] | undefined {
+	const entries = zodDef(schema).entries;
+	return entries ? Object.values(entries) : undefined;
+}
+
+/**
+ * Returns the shape map of a `ZodObject`, or `undefined` when the schema is
+ * not an object schema. Prefers the direct `.shape` accessor exposed on the
+ * instance and falls back to `def.shape`.
+ */
+export function zodShape(schema: unknown): Record<string, unknown> | undefined {
+	const s = asMaybeZod(schema);
+	if (s.shape && typeof s.shape === "object") return s.shape;
+	const defShape = s.def?.shape;
+	if (defShape && typeof defShape === "object") return defShape;
+	return undefined;
+}
+
+/** Returns the wrapped schema of `optional` / `default` / `nullable`. */
+export function zodInnerType(schema: unknown): unknown | undefined {
+	return zodDef(schema).innerType;
+}
+
+/** Returns the branch schemas of a `union`. */
+export function zodUnionOptions(schema: unknown): unknown[] | undefined {
+	return zodDef(schema).options;
+}
+
+/** Returns the item schema of an `array`. */
+export function zodArrayElement(schema: unknown): unknown | undefined {
+	return zodDef(schema).element;
+}
+
+/** Returns the input schema of a `pipe` (transform). */
+export function zodPipeInput(schema: unknown): unknown | undefined {
+	return zodDef(schema).in;
+}
+
+/** `true` when the schema reports `type === "optional"`. */
+export function isZodOptional(schema: unknown): boolean {
+	return zodTypeName(schema) === "optional";
+}
+
+/** `true` when the schema reports `type === "literal"`. */
+export function isZodLiteral(schema: unknown): boolean {
+	return zodTypeName(schema) === "literal";
+}


### PR DESCRIPTION
## Summary

Two related fixes to the OpenAPI pipeline, bundled because the tests that unlocked one revealed the other.

### 1. Zod v4 was silently unsupported

`zToJsonSchema` and `zodObjectToParams` were written against zod v3 (`_def.typeName === "ZodString"`), but the package's peer dep declares zod ^4. In v4 the metadata moved to `.def` with lowercase type names and several other shape changes (`def.element`, `def.values`, `def.entries`, `def.in`/`def.out`). The net effect: every zod schema fell through to the default branch and OpenAPI output was effectively empty for zod users.

- Added `openapi/schema-introspection.ts` — a tiny typed layer over zod v4 internals (`zodDef`, `zodTypeName`, `zodShape`, `zodLiteralValues`, `zodEnumValues`, `zodInnerType`, `zodUnionOptions`, `zodArrayElement`, `zodPipeInput`, `isZodOptional`, `isZodLiteral`). All reads against zod go through this module.
- Rewrote `zToJsonSchema` and `zodObjectToParams` to use it. Primitives, arrays, literals, enums, unions (collapsed to typed enum when all-literal), `optional` / `default` / `nullable` wrappers, objects with mixed required/optional props, and transforms (documents the input schema — what clients actually send) all produce the expected JSON Schema.
- Removed all 6 `as any` casts in `builder.ts`. Biome's `noExplicitAny` on `@ts-api-kit/core` is now clean.

### 2. Structured OpenAPI errors

`OpenAPIError` (exported from `@ts-api-kit/core/openapi`) carries a `stage` plus optional `route`, `method`, and `filePath`. Throwing sites updated:

- `file-router.ts` — the method / path consistency checks.
- `openapi/generator/index.ts` — per-file processing is wrapped with `stage: "generator-file"`; `fs.writeFile` is wrapped with `stage: "generator-write"`; the outer catch formats `OpenAPIError` with its structured prefix.

\`OpenAPIError.wrap(cause, context)\` is idempotent — it returns the original error when already an `OpenAPIError`, so context doesn't double-up as exceptions cross layers.

## Tests added

- 21 unit tests for the zod v4 introspection helpers.
- 13 tests for `zToJsonSchema` asserting end-to-end JSON Schema output for every zod shape the kit supports.
- 7 tests for `OpenAPIError` covering instance shape, Error interop, cause handling, `wrap()` prefix formatting, and idempotent re-wrapping.

Total test count: 67 passing (was 18). Lint on `@ts-api-kit/core` is error-free.

## Test plan

- [x] \`pnpm -r test\` green
- [x] \`pnpm -r lint\` green on the core package
- [x] \`pnpm -r build\` green (type-check passes)
- [ ] Reviewer: spot-check that the JSON Schema output for a route with zod schemas matches what the Scalar UI renders
- [ ] Reviewer: verify the compiler's error output now identifies the failing route when a schema can't be introspected (forced by deliberately breaking a schema)

## Follow-ups (separate PRs)

Still on the plan in \the plan:

- Split \`server.ts\` (1918 lines) into focused modules.
- Add a boot-level smoke test for \`examples/simple-example\`.
- Raise the in-flight shadcn-svelte eslint rules in \`docs/\` back to errors after the port settles.
