### PR TITLE
Dispatch zod v4 schemas to the zod converter, not valibot

### DIFF
--- a/.changeset/zod-dispatch.md
+++ b/.changeset/zod-dispatch.md
@@ -1,0 +1,11 @@
+---
+"@ts-api-kit/core": patch
+---
+
+Fix `isValibot` swallowing zod v4 schemas in `OpenAPIBuilder.addOperation`.
+
+The valibot detector only checked `typeof s.type === "string"`. Zod v4 schemas also expose a `.type` string (v4 moved from `_def.typeName === "ZodString"` to `def.type === "string"`), so every zod v4 schema passed to the OpenAPI builder entered the valibot branch and silently produced an empty `parameters` array / empty request body. The JSR release of 0.4.0 shipped with this bug — a user consuming `@ts-api-kit/core@0.4.0` with a route declared via `z.object({...})` got an OpenAPI document with `"parameters": []` even though the runtime validation ran fine.
+
+`isValibot` now additionally requires `schema["~standard"].vendor === "valibot"`. Valibot tags itself, zod tags itself, so the dispatch lands in the correct branch.
+
+Added three integration tests on `OpenAPIBuilder.addOperation` covering a zod v4 query schema, a valibot query schema, and a zod v4 body schema — the unit tests on `zToJsonSchema` passed before this fix because they bypassed the dispatch layer that actually routed zod schemas to the wrong converter.

--- a/packages/core/src/openapi/builder-integration.test.ts
+++ b/packages/core/src/openapi/builder-integration.test.ts
@@ -1,0 +1,104 @@
+// Integration tests for `OpenAPIBuilder.addOperation` that go through
+// the full dispatch path (valibot vs zod detection, parameter
+// extraction, document assembly). Unit tests in `builder.test.ts`
+// cover `zToJsonSchema` in isolation but don't exercise the dispatch
+// chain — this file does.
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import * as v from "valibot";
+import * as z from "zod";
+import { OpenAPIBuilder } from "./builder.ts";
+import { response } from "./markers.ts";
+
+const freshBuilder = () =>
+	new OpenAPIBuilder({ title: "test", version: "0.0.0" });
+
+describe("OpenAPIBuilder.addOperation — dispatch", () => {
+	it("extracts query parameters from a zod v4 schema", () => {
+		const b = freshBuilder();
+		b.addOperation({
+			method: "get",
+			path: "/",
+			summary: "",
+			request: {
+				query: z.object({
+					name: z.string().optional(),
+					page: z.number(),
+				}),
+			},
+			responses: { 200: response.of<unknown>() },
+		});
+
+		const params = b.toJSON().paths["/"].get.parameters ?? [];
+		const byName = Object.fromEntries(
+			params
+				.filter((p): p is Exclude<typeof p, { $ref: string }> => "name" in p)
+				.map((p) => [p.name, p]),
+		);
+
+		assert.ok(byName.name, "expected `name` parameter");
+		assert.equal((byName.name.schema as { type?: string }).type, "string");
+		assert.equal(byName.name.required, false);
+
+		assert.ok(byName.page, "expected `page` parameter");
+		assert.equal((byName.page.schema as { type?: string }).type, "number");
+		assert.equal(byName.page.required, true);
+	});
+
+	it("extracts query parameters from a valibot schema", () => {
+		const b = freshBuilder();
+		b.addOperation({
+			method: "get",
+			path: "/",
+			summary: "",
+			request: {
+				query: v.object({
+					name: v.optional(v.string()),
+					page: v.number(),
+				}),
+			},
+			responses: { 200: response.of<unknown>() },
+		});
+
+		const params = b.toJSON().paths["/"].get.parameters ?? [];
+		const byName = Object.fromEntries(
+			params
+				.filter((p): p is Exclude<typeof p, { $ref: string }> => "name" in p)
+				.map((p) => [p.name, p]),
+		);
+
+		assert.ok(byName.name, "expected `name` parameter");
+		assert.equal((byName.name.schema as { type?: string }).type, "string");
+		assert.equal(byName.name.required, false);
+
+		assert.ok(byName.page, "expected `page` parameter");
+		assert.equal((byName.page.schema as { type?: string }).type, "number");
+		assert.equal(byName.page.required, true);
+	});
+
+	it("treats a zod v4 body schema as JSON on the request body", () => {
+		const b = freshBuilder();
+		b.addOperation({
+			method: "post",
+			path: "/items",
+			summary: "",
+			request: {
+				body: z.object({ title: z.string(), count: z.number() }),
+			},
+			responses: { 200: response.of<unknown>() },
+		});
+
+		const body = b.toJSON().paths["/items"].post.requestBody;
+		assert.ok(body, "expected a request body");
+		const schema = body.content["application/json"].schema as {
+			type?: string;
+			properties?: Record<string, { type?: string }>;
+			required?: string[];
+		};
+		assert.equal(schema.type, "object");
+		assert.equal(schema.properties?.title?.type, "string");
+		assert.equal(schema.properties?.count?.type, "number");
+		assert.deepEqual(schema.required?.sort(), ["count", "title"]);
+	});
+});

--- a/packages/core/src/openapi/builder.ts
+++ b/packages/core/src/openapi/builder.ts
@@ -651,11 +651,15 @@ export class OpenAPIBuilder {
 function isValibot(
 	s: unknown,
 ): s is v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>> {
-	return (
-		!!s &&
-		typeof s === "object" &&
-		typeof (s as { type?: unknown }).type === "string"
-	);
+	if (!s || typeof s !== "object") return false;
+	if (typeof (s as { type?: unknown }).type !== "string") return false;
+	// Zod v4 schemas ALSO expose a `.type` string, so we'd dispatch them to
+	// the valibot path and silently emit empty OpenAPI parameters. Use the
+	// Standard Schema vendor tag to decide: valibot tags itself, zod tags
+	// itself, anything else falls through as "not valibot".
+	const vendor = (s as { "~standard"?: { vendor?: unknown } })["~standard"]
+		?.vendor;
+	return vendor === "valibot";
 }
 
 function toOperationId(method: string, path: string) {


### PR DESCRIPTION
## Summary

0.4.0 shipped broken zod support despite the whole PR #12 being about fixing zod v4. A scratch install of \`@ts-api-kit/core@0.4.0\` from JSR with a route declared as:

\`\`\`ts
export const GET = handle(
  {
    openapi: {
      request: {
        query: z.object({ name: z.string().optional(), page: z.number() }),
      },
      ...
    },
  },
  async ({ query, response }) => response.ok({ ... }),
);
\`\`\`

produced \`"parameters": []\` in \`/openapi.json\`. Runtime validation worked fine; only the documentation was empty.

## Root cause

\`isValibot\` inside \`OpenAPIBuilder\` only checked \`typeof s.type === "string"\`. Zod v4 moved from \`_def.typeName === "ZodString"\` (v3) to \`def.type === "string"\` — so a zod v4 schema's \`.type\` is always a string too, and every zod schema entered the valibot branch. The valibot parameter extractor then looked for \`schema.entries\`, didn't find it on a zod object, and silently returned an empty parameter list.

## Fix

\`isValibot\` now additionally requires \`schema["~standard"].vendor === "valibot"\`. Both libraries tag themselves via the Standard Schema protocol, so the dispatch lands in the right branch.

## Why tests missed it

The 13 tests added in #12 called \`zToJsonSchema\` directly — they never went through \`OpenAPIBuilder.addOperation\`, which is the function that actually contains the broken dispatch. This PR adds three integration tests that exercise the full path:

- Zod v4 object schema on query parameters.
- Valibot object schema on query parameters (regression guard).
- Zod v4 object schema on a request body.

All three assert shape + \`required\` correctness.

## Test plan

- [x] \`pnpm -r test\` green (70 tests, 3 new; the 3 new ones fail on \`main\` as expected before the fix).
- [x] \`pnpm -r build\` green.
- [x] \`pnpm -r lint\` green on \`@ts-api-kit/core\`.
- [ ] Reviewer: after this lands in a 0.4.1, re-run the scratch install and confirm the \`parameters\` array is populated.