### PR TITLE
Raise shadcn eslint rules back to error

### DIFF
--- a/docs/.prettierrc
+++ b/docs/.prettierrc
@@ -3,6 +3,7 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
+	"endOfLine": "auto",
 	"plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],
 	"overrides": [
 		{

--- a/docs/eslint.config.js
+++ b/docs/eslint.config.js
@@ -25,18 +25,44 @@ export default defineConfig(
 			// typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
 			// see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
 			'no-undef': 'off',
-			// Demoted to warnings while the shadcn-svelte port is still in flight.
-			// Upstream shadcn-svelte templates frequently ship without explicit
-			// each-keys, raw anchor tags, or SvelteSet wrappers — fixing them case
-			// by case belongs in a follow-up dedicated pass, not in the merge that
-			// lands the port.
-			'svelte/require-each-key': 'warn',
-			'svelte/no-navigation-without-resolve': 'warn',
-			'svelte/prefer-svelte-reactivity': 'warn',
+			// All three rules are back at error level now that the first-party
+			// code in this workspace passes them. Shadcn-svelte templates that
+			// can't comply (generic anchor primitives, auto-imported tables)
+			// are downgraded below on a per-glob basis — prefer that over
+			// disabling repo-wide.
+			'svelte/require-each-key': 'error',
+			'svelte/no-navigation-without-resolve': 'error',
+			'svelte/prefer-svelte-reactivity': 'error',
 			'@typescript-eslint/no-unused-vars': [
 				'error',
 				{ argsIgnorePattern: '^_', varsIgnorePattern: '^_' }
 			]
+		}
+	},
+	{
+		// Components under `src/lib/components/ui/` come from the shadcn-svelte
+		// registry. They're generic primitives (e.g. Button forwards an
+		// unrestricted href to <a>) and a mutable auto-tracked data-table
+		// backing store that's expected to use a plain Set for perf reasons.
+		// Rewriting them diverges from the shadcn upstream for no practical
+		// gain, so the two rules the registry violates are demoted there.
+		files: ['src/lib/components/ui/**/*.{svelte,ts,js}'],
+		rules: {
+			'svelte/no-navigation-without-resolve': 'off',
+			'svelte/prefer-svelte-reactivity': 'off'
+		}
+	},
+	{
+		// The landing page builds its nav from plain-text data arrays whose
+		// hrefs are a mix of in-page anchors (`#...`) and external URLs (with
+		// `target="_blank"`). `svelte/no-navigation-without-resolve` wants
+		// every `<a href>` wrapped with `resolveRoute()`, but that helper
+		// throws on non-route hrefs, so the rule's prescription breaks this
+		// page. Disable it for this file; when the page is restructured to
+		// use real route patterns this override can go.
+		files: ['src/routes/+page.svelte'],
+		rules: {
+			'svelte/no-navigation-without-resolve': 'off'
 		}
 	},
 	{

--- a/docs/src/lib/components/docs/mode-toggle.svelte
+++ b/docs/src/lib/components/docs/mode-toggle.svelte
@@ -47,7 +47,7 @@
 	<DropdownMenuContent align="end" class="w-44">
 		<DropdownMenuLabel>Theme</DropdownMenuLabel>
 		<DropdownMenuSeparator />
-		{#each options as option}
+		{#each options as option (option.value)}
 			<!-- @ts-expect-error bits-ui doesn't expose select event typings -->
 			<DropdownItem onselect={() => handleSelect(option.value)}>
 				<option.icon class="size-4" />

--- a/docs/src/lib/components/docs/sidebar-nav.svelte
+++ b/docs/src/lib/components/docs/sidebar-nav.svelte
@@ -34,12 +34,12 @@
 	}
 </script>
 
-{#each sections as section}
+{#each sections as section (section.title)}
 	<SidebarGroup>
 		<SidebarGroupLabel>{section.title}</SidebarGroupLabel>
 		<SidebarGroupContent>
 			<SidebarMenu>
-				{#each section.items as item}
+				{#each section.items as item (item.href)}
 					<SidebarMenuItem>
 						<SidebarButton isActive={item.href === activeHref} onclick={() => navigateTo(item)}>
 							<span class="truncate">{item.title}</span>

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -174,7 +174,7 @@
 						<nav
 							class="hidden items-center gap-1 text-sm font-medium text-muted-foreground lg:flex"
 						>
-							{#each TOP_NAV_LINKS as link}
+							{#each TOP_NAV_LINKS as link (link.href)}
 								<a
 									href={link.href}
 									class="rounded-md px-3 py-1.5 transition-colors hover:bg-muted/60 hover:text-foreground"
@@ -264,7 +264,7 @@
 						</section>
 
 						<section class="grid gap-4 md:grid-cols-3">
-							{#each featureHighlights as feature}
+							{#each featureHighlights as feature (feature.title)}
 								<Card class="border-border/70 bg-muted/20">
 									<CardHeader class="flex flex-row items-center gap-3 pb-2">
 										<feature.icon class="size-5 text-primary" />
@@ -298,13 +298,13 @@
 							<div class="space-y-4 px-4 py-4">
 								<Tabs bind:value={installTab} class="space-y-4">
 									<TabsList class="flex w-full flex-wrap gap-2 rounded-lg bg-muted/40 p-1">
-										{#each installTabs as option}
+										{#each installTabs as option (option.value)}
 											<TabsTrigger value={option.value} class="flex-1">
 												{option.label}
 											</TabsTrigger>
 										{/each}
 									</TabsList>
-									{#each installTabs as option}
+									{#each installTabs as option (option.value)}
 										<TabsContent value={option.value} class="mt-0">
 											<div
 												class="relative overflow-hidden rounded-lg border border-border/70 bg-background font-mono text-sm"
@@ -341,7 +341,7 @@
 									Use these links to dive deeper into the essentials.
 								</p>
 								<div class="grid gap-4 md:grid-cols-3">
-									{#each quickLinks as link}
+									{#each quickLinks as link (link.href)}
 										<a
 											href={link.href}
 											class="group flex flex-col gap-2 rounded-xl border border-border/60 bg-muted/20 p-4 transition-colors hover:border-primary/40 hover:bg-muted/40"
@@ -373,7 +373,7 @@
 								On this page
 							</p>
 							<nav class="mt-3 flex flex-col gap-1 text-sm text-muted-foreground">
-								{#each tableOfContents as item}
+								{#each tableOfContents as item (item.id)}
 									<a
 										href={`#${item.id}`}
 										class="rounded-md px-2 py-1 transition-colors hover:bg-muted/50 hover:text-foreground"


### PR DESCRIPTION
## Summary

Walks back the temporary "demote to warning" escape hatch from the shadcn-svelte port (#11). The three rules that were flagged as warnings across the docs workspace —

- \`svelte/require-each-key\`
- \`svelte/no-navigation-without-resolve\`
- \`svelte/prefer-svelte-reactivity\`

— are back at \`error\` level. First-party code passes them after this PR; two places that genuinely can't get **scoped** overrides in \`eslint.config.js\` rather than a repo-wide downgrade:

- **\`src/lib/components/ui/**\`** — shadcn registry primitives. \`Button\` forwards arbitrary hrefs (external URLs, anchors, pre-resolved routes) so \`resolveRoute()\` doesn't apply; a data-table's backing store uses a plain \`Set\` intentionally for perf. Rewriting to diverge from the upstream registry for no practical gain is worse than the scoped override.
- **\`src/routes/+page.svelte\`** — marketing page whose \`<a href>\` values are a mix of in-page anchors and external URLs with \`target="_blank"\`. \`resolveRoute()\` throws on non-route inputs. When the page is restructured to use real route patterns, this override can go.

## Each-keys added

- \`mode-toggle.svelte\`: theme options keyed by \`option.value\`.
- \`sidebar-nav.svelte\`: sections by \`section.title\`, items by \`item.href\`.
- \`+page.svelte\`: \`TOP_NAV_LINKS\` by href, \`featureHighlights\` by title, \`installTabs\` by value (×2), \`quickLinks\` by href, \`tableOfContents\` by id.

## \`endOfLine: auto\` in \`.prettierrc\`

Unrelated nit that was blocking prettier on Windows checkouts — files on disk are CRLF (courtesy of git's autocrlf), prettier was comparing against LF and flagging 329 files. \`auto\` makes prettier respect whatever is on disk; git's autocrlf still normalises to LF on commit, so the stored blobs don't change.

## Test plan

- [x] \`pnpm -r lint\` green on the docs workspace.
- [x] \`pnpm -r test\` green.
- [x] \`pnpm --filter ts-api-kit-docs build\` green.
- [ ] Reviewer: sanity-check the two scoped overrides read as documentation, not "we gave up". Happy to inline more prose.