### PR TITLE
Default OpenAPI mode to "none" so zod routes render in /openapi.json

### DIFF
--- a/.changeset/default-openapi-mode.md
+++ b/.changeset/default-openapi-mode.md
@@ -1,0 +1,20 @@
+---
+"@ts-api-kit/core": minor
+---
+
+Default OpenAPI generation mode is now `"none"` (runtime builder), not `"memory"` (AST compiler).
+
+### Why
+
+A scratch install of `@ts-api-kit/core@0.4.1` from JSR with a zod v4 route still produced `"parameters": []` in `/openapi.json`. The 0.4.1 fix was to the in-memory `OpenAPIBuilder`, which is only used when `openapiOutput` is `"none"` or `"file"`. The default runtime path — `openapiOutput: "memory"` — dispatches to the AST-based compiler (`packages/core/src/openapi/generator/index.ts`), and that compiler was written valibot-first: it never learned to recognise `z.object({...})`, so every zod route serialised with empty parameters and empty request bodies.
+
+### What changes
+
+- `serve()` and the module-level default both initialise `openapiOutput` to `"none"` instead of `"memory"`.
+- The runtime `/openapi.json` handler picks the fallback branch on the default path, which uses `buildOpenAPIDocument` — the builder that #16 fixed to dispatch zod v4 schemas correctly. Both valibot and zod routes now emit the expected parameters / request bodies / responses.
+- The simple-example smoke test was strengthened from "the document has paths" to actively asserting that the root route's `id: z.number()` query parameter is emitted with `{ name, in: "query", schema: { type: "number" } }`. Caught the regression locally; would have caught it in 0.4.0 / 0.4.1 too.
+
+### Who is affected
+
+- **Zod users:** strictly better — parameters and request bodies now render correctly without any config change.
+- **Valibot users:** unchanged for routes whose schemas are fully captured at the handler-registration level. If you relied on the AST compiler to extract rich response types from `response.of<MyType>()` generic arguments, pass `serve({ openapiOutput: "memory" })` explicitly to opt back in. Future work: teach the compiler to recognise zod so `"memory"` supports both schema libraries.

--- a/examples/simple-example/src/smoke.test.ts
+++ b/examples/simple-example/src/smoke.test.ts
@@ -38,7 +38,7 @@ describe("simple-example smoke", () => {
 		assert.equal(res.status, 400);
 	});
 
-	it("exposes the generated /openapi.json", async () => {
+	it("exposes the generated /openapi.json with zod query parameters populated", async () => {
 		const server = new Server();
 		await server.configureRoutes(routesDir);
 
@@ -49,12 +49,36 @@ describe("simple-example smoke", () => {
 
 		const doc = (await res.json()) as {
 			openapi?: string;
-			paths?: Record<string, unknown>;
+			paths?: Record<
+				string,
+				Record<
+					string,
+					{
+						parameters?: Array<{
+							name?: string;
+							in?: string;
+							schema?: { type?: string };
+						}>;
+					}
+				>
+			>;
 		};
 		assert.ok(
 			typeof doc.openapi === "string" && doc.openapi.startsWith("3."),
 			"expected an openapi 3.x document",
 		);
 		assert.ok(doc.paths, "expected paths to be present in the document");
+
+		// Regression guard: the root route declares a zod `id: z.number()`
+		// query schema. Before the openapi default-mode fix (0.4.2) the
+		// compiler pipeline (default) only understood valibot, so zod
+		// routes serialised with an empty parameters array. Assert the
+		// parameter is now emitted with the right shape.
+		const rootGet = doc.paths?.["/"]?.get;
+		assert.ok(rootGet, "expected GET / in the document");
+		const idParam = rootGet.parameters?.find((p) => p.name === "id");
+		assert.ok(idParam, "expected `id` query parameter to be emitted");
+		assert.equal(idParam.in, "query");
+		assert.equal(idParam.schema?.type, "number");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,11 +82,15 @@ export const serve = async (options: ServeOptions = {}): Promise<void> => {
 
 	await server.configureRoutes(routesDir);
 
-	// Decide generation mode and file path
+	// Decide generation mode and file path. Default is "none" so the
+	// runtime `/openapi.json` is served from the in-memory builder, which
+	// supports both valibot and zod. Opt into "memory" for the AST-based
+	// compiler pipeline when richer response-type extraction is wanted
+	// (valibot-only today).
 	const outOpt =
 		typeof options.openapiOutput === "string"
 			? { mode: options.openapiOutput }
-			: (options.openapiOutput ?? { mode: "memory" });
+			: (options.openapiOutput ?? { mode: "none" });
 	const mode = (outOpt.mode ?? "none") as "file" | "memory" | "none";
 	const outPath = outOpt.path || "./openapi.json";
 	setOpenAPIGeneration({

--- a/packages/core/src/openapi/overrides.ts
+++ b/packages/core/src/openapi/overrides.ts
@@ -25,7 +25,14 @@ export type RootOverrides = Partial<{
 let ROOT_OVERRIDES: RootOverrides | undefined;
 let DEFAULT_OVERRIDES: RootOverrides | undefined;
 type OpenAPIMode = "file" | "memory" | "none";
-let OPENAPI_MODE: OpenAPIMode = "memory";
+// Default to "none" so the runtime `/openapi.json` handler uses the
+// in-memory builder (driven by handler registrations) instead of the
+// AST-based compiler. The compiler path only understands valibot
+// patterns, so defaulting to "memory" silently produced empty
+// parameters for zod routes. Users who want the compiler's richer
+// response-type extraction can opt in with
+// `serve({ openapiOutput: "memory" })`.
+let OPENAPI_MODE: OpenAPIMode = "none";
 let OPENAPI_FILE_PATH: string = "./openapi.json";
 let OPENAPI_PROJECT_PATH: string = "./tsconfig.json";
 


### PR DESCRIPTION
## Summary

0.4.1 fixed the in-memory \`OpenAPIBuilder\` dispatch for zod v4 (#16), but a scratch install from JSR with a \`z.object({...})\` query still produced \`"parameters": []\`. The builder fix never reached the code path users actually hit.

### Why

The default \`openapiOutput: "memory"\` routes \`/openapi.json\` to the AST-based compiler in \`packages/core/src/openapi/generator/index.ts\`, not to the builder. That compiler was written valibot-first — it has no zod recognition at all, so every zod route serialised empty.

### What changes

- \`packages/core/src/openapi/overrides.ts\`: module-level default \`OPENAPI_MODE\` is now \`"none"\`.
- \`packages/core/src/index.ts\`: \`serve()\` falls back to \`"none"\` when the caller doesn't specify \`openapiOutput\`.

With mode \`"none"\`, \`/openapi.json\` goes through \`buildOpenAPIDocument\` — the builder that #16 fixed. Both valibot and zod routes now emit the expected parameters, request bodies, and responses (for the runtime-registered data).

### Who is affected

- **Zod users:** strictly better — parameters and request bodies now render correctly with no config change.
- **Valibot users:** unchanged for handler-registered schemas. If you relied on the compiler to extract rich response types from \`response.of<MyType>()\` generic arguments, pass \`serve({ openapiOutput: "memory" })\` explicitly to opt back in.

### Follow-up

Long-term fix: teach the compiler to recognise zod so \`"memory"\` supports both schema libraries. Out of scope for this patch.

## Regression guard

The simple-example smoke test was strengthened from "the document has paths" (which passed even with empty parameters, which is exactly why 0.4.1 shipped broken) to actively asserting the root route's \`id: z.number()\` query parameter emits \`{ name, in: "query", schema: { type: "number" } }\`.

## Test plan

- [x] 74 tests pass (70 core + 3 simple-example + 1 docs)
- [x] Scratch install of a rebuilt \`@ts-api-kit/core\` against this branch emits zod parameters correctly
- [x] Simple-example smoke test exercises the full \`/openapi.json\` → builder path and asserts parameter shape
- [ ] Reviewer: after this lands as 0.4.2, re-run \`npx jsr add @ts-api-kit/core\` in a scratch project and confirm zod params render